### PR TITLE
fix blurred video

### DIFF
--- a/_includes/vimeo.html
+++ b/_includes/vimeo.html
@@ -73,7 +73,7 @@
 {%- if include.texttrack != nil %}
     {% assign texttrack = include.texttrack %}
 {% else %}
-    {% assign texttrack = '0' %}
+    {% assign texttrack = '' %}
 {% endif -%}
 
 {%- if include.showVimeoTitle != nil and include.showVimeoTitle == true %}


### PR DESCRIPTION
This fixes the ongoing blurred video issue for embedded vimeo videos by removing {% assign texttrack = '0' %}  and replacing with {% assign texttrack = '' %}